### PR TITLE
Make agent run

### DIFF
--- a/src/main/java/ca/bazlur/BookRecommendationApplication.java
+++ b/src/main/java/ca/bazlur/BookRecommendationApplication.java
@@ -11,6 +11,7 @@ import org.springframework.ai.mcp.client.autoconfigure.McpClientAutoConfiguratio
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
@@ -19,8 +20,8 @@ import java.time.Instant;
 
 
 @SpringBootApplication(scanBasePackages = {
-        "ca.bazlur.agent",
-        "ca.bazlur.model"
+        "ca.bazlur",
+        "com.embabel.agent",
 }, exclude = {McpClientAutoConfiguration.class})
 @EnableConfigurationProperties(BookRecommendationProperties.class)
 public class BookRecommendationApplication {

--- a/src/main/java/ca/bazlur/agent/BookRecommendationAgent.java
+++ b/src/main/java/ca/bazlur/agent/BookRecommendationAgent.java
@@ -12,6 +12,7 @@ import com.embabel.agent.domain.io.UserInput;
 import com.embabel.common.ai.model.BuildableLlmOptions;
 import com.embabel.common.ai.model.LlmOptions;
 import com.embabel.common.ai.model.ModelSelectionCriteria;
+import com.embabel.common.util.DummyInstanceCreator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
@@ -23,7 +24,7 @@ import static com.embabel.agent.api.annotation.ActionMethodPromptRunnerKt.using;
 
 @Agent(
         description = "Recommend books based on reading history, preferences, and personalized analysis",
-        scan = false
+        scan = true
 )
 public class BookRecommendationAgent {
 
@@ -32,6 +33,11 @@ public class BookRecommendationAgent {
 
     public BookRecommendationAgent(BookRecommendationProperties recommendationProperties) {
         this.recommendationProperties = recommendationProperties;
+    }
+
+    @Action
+    public ReadingHistory retrieveReadingHistory() {
+        throw new UnsupportedOperationException("Reading history object must be available or next action cannot run");
     }
 
     @Action

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # Spring application name
 spring.application.name=book-recommendation-engine
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.neo4j.Neo4jAutoConfiguration
 
 # Logging configuration
 logging.level.ca.bazlur=INFO


### PR DESCRIPTION
- Modify application class scanning config
- Remove `scan = false` on agent, which prevented classpath scanning picking it up

Agent now runs but fails on `UnsupportedOperationException`. I'm not sure how you want to retrieve the reading history. A repository would work. Really nice repository integration is on the roadmap, where it could try to retrieve from user input, for example.